### PR TITLE
Было обращение к несуществующей переменной template_file

### DIFF
--- a/examples/21_jinja2/3_template_syntax/cfg_gen.py
+++ b/examples/21_jinja2/3_template_syntax/cfg_gen.py
@@ -5,7 +5,7 @@ import sys
 import os
 
 #$ python cfg_gen.py templates/for.txt data_files/for.yml
-template_dir, template = os.path.split(sys.argv[1])
+template_dir, template_file = os.path.split(sys.argv[1])
 
 vars_file = sys.argv[2]
 


### PR DESCRIPTION
Название шаблона сохранялось в переменную `template`
`template_dir, template = os.path.split(sys.argv[1])`,
а ниже происходит обращение к переменной `template_file`
`template = env.get_template(template_file)`